### PR TITLE
Elide bad init.go from Go codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           go-version: '1.16.x'
       - name: Run Go Build
-        run: go build main.go
+        run: |
+            go build -ldflags="-X github.com/pulumi/crd2pulumi/gen.Version=0.0.1" -o "${{ github.workspace }}/bin/crd2pulumi" main.go
+            echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
       - name: Run tests
         run: go test -v .
         working-directory: tests

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ ensure::
 
 build::
 	$(GO) build $(PROJECT)
+
+test::
+	$(GO) test -v ./tests/

--- a/gen/golang.go
+++ b/gen/golang.go
@@ -23,8 +23,12 @@ import (
 )
 
 var unneededGoFiles = codegen.NewStringSet(
+	// The root directory doesn't define any resources:
 	"doc.go",
+	"init.go",
 	"provider.go",
+
+	// We use the standard Kubernetes meta/v1 types, so skip generating them:
 	"meta/v1/pulumiTypes.go",
 )
 

--- a/tests/crds/GoogleCloudPlatform/gke-managed-certs/README.md
+++ b/tests/crds/GoogleCloudPlatform/gke-managed-certs/README.md
@@ -1,0 +1,3 @@
+Taken from
+https://github.com/GoogleCloudPlatform/gke-managed-certs/blob/master/deploy/managedcertificates-crd.yaml
+

--- a/tests/crds/GoogleCloudPlatform/gke-managed-certs/managedcertificates-crd.yaml
+++ b/tests/crds/GoogleCloudPlatform/gke-managed-certs/managedcertificates-crd.yaml
@@ -1,0 +1,177 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedcertificates.networking.gke.io
+spec:
+  group: networking.gke.io
+  versions:
+  - name: v1beta1  # (Deprecated)
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            type: object
+            properties:
+              certificateStatus:
+              # The status of the managed certificate.
+                type: string
+              domainStatus:
+              # The status of certificate provisioning for domains
+              # selected by the user.
+                type: array
+                items:
+                  type: object
+                  required:
+                  - domain
+                  - status
+                  properties:
+                    domain:
+                      type: string
+                    status:
+                      type: string
+              certificateName:
+              # The name of the provisioned managed certificate.
+                type: string
+              expireTime:
+              # The expire time of the provisioned managed certificate.
+              # The certificate will be renewed automatically unless
+              # the DNS configuration changes and prevents that.
+                type: string
+                format: date-time
+          spec:
+            type: object
+            properties:
+              domains:
+              # One non-wildcard domain name up to 63 characters long.
+                type: array
+                maxItems: 1
+                items:
+                  type: string
+                  maxLength: 63
+                  pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+  - name: v1beta2  # (Deprecated)
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            type: object
+            properties:
+              certificateStatus:
+              # The status of the managed certificate.
+                type: string
+              domainStatus:
+              # The status of certificate provisioning for domains
+              # selected by the user.
+                type: array
+                items:
+                  type: object
+                  required:
+                  - domain
+                  - status
+                  properties:
+                    domain:
+                      type: string
+                    status:
+                      type: string
+              certificateName:
+              # The name of the provisioned managed certificate.
+                type: string
+              expireTime:
+              # The expire time of the provisioned managed certificate.
+              # The certificate will be renewed automatically unless
+              # the DNS configuration changes and prevents that.
+                type: string
+                format: date-time
+          spec:
+            type: object
+            properties:
+              domains:
+              # Up to 100 non-wildcard domain names, each up to 63 characters long.
+                type: array
+                maxItems: 100
+                items:
+                  type: string
+                  maxLength: 63
+                  pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            type: object
+            properties:
+              certificateStatus:
+              # The status of the managed certificate.
+                type: string
+              domainStatus:
+              # The status of certificate provisioning for domains
+              # selected by the user.
+                type: array
+                items:
+                  type: object
+                  required:
+                  - domain
+                  - status
+                  properties:
+                    domain:
+                      type: string
+                    status:
+                      type: string
+              certificateName:
+              # The name of the provisioned managed certificate.
+                type: string
+              expireTime:
+              # The expire time of the provisioned managed certificate.
+              # The certificate will be renewed automatically unless
+              # the DNS configuration changes and prevents that.
+                type: string
+                format: date-time
+          spec:
+            type: object
+            properties:
+              domains:
+              # Up to 100 non-wildcard domain names, each up to 63 characters long.
+                type: array
+                maxItems: 100
+                items:
+                  type: string
+                  maxLength: 63
+                  pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Status
+      type: string
+      description: Status of the managed certificate
+      jsonPath: .status.certificateStatus
+  scope: Namespaced
+  names:
+    plural: managedcertificates
+    singular: managedcertificate
+    kind: ManagedCertificate
+    shortNames:
+    - mcrt

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCRDs enumerates all CRD YAML files, and generates them in each language.
+func TestCRDs(t *testing.T) {
+	filepath.WalkDir("crds", func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() && (filepath.Ext(path) == ".yml" || filepath.Ext(path) == ".yaml") {
+			for _, lang := range []string{"dotnet", "go", "nodejs", "python"} {
+				tmpdir, err := ioutil.TempDir("", "")
+				assert.Nil(t, err, "expected to create a temp dir for the CRD output")
+				defer os.RemoveAll(tmpdir)
+				langFlag := "--" + lang + "Path"
+				t.Logf("crd2pulumi %s=%s %s: running", langFlag, tmpdir, path)
+				crdCmd := exec.Command("crd2pulumi", langFlag, tmpdir, "--force", path)
+				crdOut, err := crdCmd.CombinedOutput()
+				t.Logf("crd2pulumi %s=%s %s: output=\n%s", langFlag, tmpdir, path, crdOut)
+				assert.Nil(t, err, "expected crd2pulumi for '%s=%s %s' to succeed", langFlag, tmpdir, path)
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
We correctly skip provider.go, since there are no resources in the
root of the module, but were still emitting init.go. This led to
issue #44, because the init.go code assumes the Provider type exists.
The fix is to also skip emitting init.go.

I would like to add a regression test, but need help figuring out
where that would go, as I didn't see a natural place for it.