### PR TITLE
Support stdin as yaml source

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -123,11 +123,20 @@ type PackageGenerator struct {
 	schemaPackageWithObjectMetaType *pschema.Package
 }
 
+// Read contents of file, with special case for stdin '-'
+func ReadFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return ioutil.ReadAll(os.Stdin)
+	} else {
+		return ioutil.ReadFile(path)
+	}
+}
+
 func NewPackageGenerator(yamlPaths []string) (PackageGenerator, error) {
 	yamlFiles := make([][]byte, 0, len(yamlPaths))
 
 	for _, yamlPath := range yamlPaths {
-		yamlFile, err := ioutil.ReadFile(yamlPath)
+		yamlFile, err := ReadFileOrStdin(yamlPath)
 		if err != nil {
 			return PackageGenerator{}, errors.Wrapf(err, "could not read file %s", yamlPath)
 		}


### PR DESCRIPTION
# Problem
`crd2pulumi` only accepts CRD yaml files as file path args. It is common to support `stdin` as an input source indicated by a `-` (dash). This opens the doors for command pipelining and integrations.

Eg.
```bash
$ cat my-crd.yaml | crd2pulumi -n -
```

# Solution
Add a special case for `"-"` that will read the yaml contents from `stdin` instead of a file.