### PR TITLE
Fix x-kubernetes-int-or-string precedence

### DIFF
--- a/gen/schema.go
+++ b/gen/schema.go
@@ -194,6 +194,11 @@ func GetTypeSpec(schema map[string]interface{}, name string, types map[string]ps
 		return anyTypeSpec
 	}
 
+	intOrString, foundIntOrString, _ := unstruct.NestedBool(schema, "x-kubernetes-int-or-string")
+	if foundIntOrString && intOrString {
+		return intOrStringTypeSpec
+	}
+
 	// If the schema is of the `oneOf` type: return a TypeSpec with the `OneOf`
 	// field filled with the TypeSpec of all sub-schemas.
 	oneOf, foundOneOf, _ := NestedMapSlice(schema, "oneOf")
@@ -227,11 +232,6 @@ func GetTypeSpec(schema map[string]interface{}, name string, types map[string]ps
 	if foundAnyOf {
 		combinedSchema := CombineSchemas(false, anyOf...)
 		return GetTypeSpec(combinedSchema, name, types)
-	}
-
-	intOrString, foundIntOrString, _ := unstruct.NestedBool(schema, "x-kubernetes-int-or-string")
-	if foundIntOrString && intOrString {
-		return intOrStringTypeSpec
 	}
 
 	preserveUnknownFields, foundPreserveUnknownFields, _ := unstruct.NestedBool(schema, "x-kubernetes-preserve-unknown-fields")


### PR DESCRIPTION
Give `x-kubernetes-int-or-string` precedence over `anyOf`, `allOf` and `oneOf`.

Fix issue #46 by rearranging the code to match on `x-kubernetes-int-or-string` before `anyOf`, `allOf` and `oneOf` as described in the comment here: https://github.com/pulumi/crd2pulumi/issues/46#issuecomment-971719636