### PR TITLE
Add generating CRD from URL

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ CustomResourceDefinition YAML schema.`
 const example = `crd2pulumi --nodejs crontabs.yaml
 crd2pulumi -dgnp crd-certificates.yaml crd-issuers.yaml crd-challenges.yaml
 crd2pulumi --pythonPath=crds/python/istio --nodejsPath=crds/nodejs/istio crd-all.gen.yaml crd-mixer.yaml crd-operator.yaml
+crd2pulumi --pythonPath=crds/python/gke https://raw.githubusercontent.com/GoogleCloudPlatform/gke-managed-certs/master/deploy/managedcertificates-crd.yaml
 
 Notice that by just setting a language-specific output path (--pythonPath, --nodejsPath, etc) the code will
 still get generated, so setting -p, -n, etc becomes unnecessary.
@@ -117,7 +118,7 @@ func NewLanguageSettings(flags *pflag.FlagSet) (gen.LanguageSettings, []string) 
 		if golang {
 			notices = append(notices, "-g is not necessary if --goPath is already set")
 		}
-	} else if golang || goName != gen.DefaultName{
+	} else if golang || goName != gen.DefaultName {
 		path := filepath.Join(defaultOutputPath, Go)
 		ls.GoPath = &path
 	}

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -25,22 +25,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestCRDs enumerates all CRD YAML files, and generates them in each language.
-func TestCRDs(t *testing.T) {
+var languages = []string{"dotnet", "go", "nodejs", "python"}
+
+const gkeManagedCertsUrl = "https://raw.githubusercontent.com/GoogleCloudPlatform/gke-managed-certs/master/deploy/managedcertificates-crd.yaml"
+
+// execCrd2Pulumi runs the crd2pulumi binary in a temporary directory
+func execCrd2Pulumi(t *testing.T, lang, path string) {
+	tmpdir, err := ioutil.TempDir("", "")
+	assert.Nil(t, err, "expected to create a temp dir for the CRD output")
+	defer os.RemoveAll(tmpdir)
+	langFlag := "--" + lang + "Path"
+	t.Logf("crd2pulumi %s=%s %s: running", langFlag, tmpdir, path)
+	crdCmd := exec.Command("crd2pulumi", langFlag, tmpdir, "--force", path)
+	crdOut, err := crdCmd.CombinedOutput()
+	t.Logf("crd2pulumi %s=%s %s: output=\n%s", langFlag, tmpdir, path, crdOut)
+	assert.Nil(t, err, "expected crd2pulumi for '%s=%s %s' to succeed", langFlag, tmpdir, path)
+}
+
+// TestCRDsFromFile enumerates all CRD YAML files, and generates them in each language.
+func TestCRDsFromFile(t *testing.T) {
 	filepath.WalkDir("crds", func(path string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && (filepath.Ext(path) == ".yml" || filepath.Ext(path) == ".yaml") {
-			for _, lang := range []string{"dotnet", "go", "nodejs", "python"} {
-				tmpdir, err := ioutil.TempDir("", "")
-				assert.Nil(t, err, "expected to create a temp dir for the CRD output")
-				defer os.RemoveAll(tmpdir)
-				langFlag := "--" + lang + "Path"
-				t.Logf("crd2pulumi %s=%s %s: running", langFlag, tmpdir, path)
-				crdCmd := exec.Command("crd2pulumi", langFlag, tmpdir, "--force", path)
-				crdOut, err := crdCmd.CombinedOutput()
-				t.Logf("crd2pulumi %s=%s %s: output=\n%s", langFlag, tmpdir, path, crdOut)
-				assert.Nil(t, err, "expected crd2pulumi for '%s=%s %s' to succeed", langFlag, tmpdir, path)
+			for _, lang := range languages {
+				execCrd2Pulumi(t, lang, path)
 			}
 		}
 		return nil
 	})
+}
+
+// TestCRDsFromUrl pulls the CRD YAML file from a URL and generates it in each language
+func TestCRDsFromUrl(t *testing.T) {
+	for _, lang := range languages {
+		execCrd2Pulumi(t, lang, gkeManagedCertsUrl)
+	}
 }


### PR DESCRIPTION
resolves #53 

Adds support for pulling the CRD from a URL by checking if the provided path is URL-like and then fetching it from the server. If it is not URL-like, it falls back on reading from the filesystem.