### PR TITLE
Fix Golang CRD Generation

### DIFF
--- a/gen/golang.go
+++ b/gen/golang.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-	"path/filepath"
 )
 
 var unneededGoFiles = codegen.NewStringSet(
@@ -50,6 +49,7 @@ func (pg *PackageGenerator) genGoFiles(name string) (map[string]*bytes.Buffer, e
 	moduleToPackage["meta/v1"] = "meta/v1"
 	pkg.Language["go"] = rawMessage(map[string]interface{}{
 		"importBasePath":  "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes",
+		"rootPackageName": name,
 		"moduleToPackage": moduleToPackage,
 		"packageImportAliases": map[string]interface{}{
 			"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1": "metav1",
@@ -67,9 +67,8 @@ func (pg *PackageGenerator) genGoFiles(name string) (map[string]*bytes.Buffer, e
 	buffers := map[string]*bytes.Buffer{}
 
 	for path, code := range files {
-		newPath, _ := filepath.Rel(name, path)
-		if !unneededGoFiles.Has(newPath) {
-			buffers[newPath] = bytes.NewBuffer(code)
+		if !unneededGoFiles.Has(path) {
+			buffers[path] = bytes.NewBuffer(code)
 		}
 	}
 


### PR DESCRIPTION
There are two issues with the current implementation for generating CRDs in golang that aren't present (or at least don't appear to be when running locally and comparing directory structure) in the other languages. 

1. Without specifying `rootPackageName` in the json for the eventual `GoPackageInfo`, everything gets put into a directory called `kubernetes` instead of `go` or whatever the user passes in via flags.
1. The upstream pulumi code gen is already ensuring that the file paths are relative, so an unnecessary `../` was being appended

If you were to run the tool as is, it would create a folder called `kubernetes` in the directory it was ran in instead of `crds/go` 