### PR TITLE
Disable CGO, fixes macOS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 PROJECT      := github.com/pulumi/crd2pulumi
 VERSION      ?= $(shell (command -v pulumictl > /dev/null && pulumictl get version || echo "0.0.0-dev"))
 VERSION_PATH := cmd.Version
+GO           ?= go
 
-GO              ?= go
+export CGO_ENABLED := 0
 
 all:: ensure build test
 


### PR DESCRIPTION
The package github.com/rjeczalik/notify is referenced indirectly via
github.com/pulumi/pulumi/pkg/v3 and uses CGO on macOS by default.
Disable this behavior by setting CGO_ENABLED=0
