### PR TITLE
Revert change that added default paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 CHANGELOG
 =========
 
-## 1.2.1 (2022-06-16)
+## 1.2.2 (2022-07-20)
+- Fix regression that caused code in all languages to be generated regardless of selection.
+
+## 1.2.1 (2022-07-19)
 This release is a refactor with no user-affecting changes.
 - Create public interface for codegen in the `pkg/codegen` namespace
   while placing internal utilities under `internal/`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,10 +122,10 @@ func Execute() error {
 	f.StringVarP(&nodejsSettings.PackageName, "nodejsName", "", codegen.DefaultName, "name of generated NodeJS package")
 	f.StringVarP(&pythonSettings.PackageName, "pythonName", "", codegen.DefaultName, "name of generated Python paclkage")
 
-	f.StringVarP(&dotNetSettings.OutputDir, "dotnetPath", "", "crds/dotnet", "optional .NET output dir")
-	f.StringVarP(&goSettings.OutputDir, "goPath", "", "crds/go", "optional Go output dir")
-	f.StringVarP(&nodejsSettings.OutputDir, "nodejsPath", "", "crds/nodejs", "optional NodeJS output dir")
-	f.StringVarP(&pythonSettings.OutputDir, "pythonPath", "", "crds/python", "optional Python output dir")
+	f.StringVarP(&dotNetSettings.OutputDir, "dotnetPath", "", "", "optional .NET output dir")
+	f.StringVarP(&goSettings.OutputDir, "goPath", "", "", "optional Go output dir")
+	f.StringVarP(&nodejsSettings.OutputDir, "nodejsPath", "", "", "optional NodeJS output dir")
+	f.StringVarP(&pythonSettings.OutputDir, "pythonPath", "", "", "optional Python output dir")
 
 	f.BoolVarP(&dotNetSettings.ShouldGenerate, "dotnet", "d", false, "generate .NET")
 	f.BoolVarP(&goSettings.ShouldGenerate, "go", "g", false, "generate Go")


### PR DESCRIPTION
This inadvertantly caused all languages to be generated (because their
path being set implies so)
