### PR TITLE
Proposed docs update in TypeScript example (To mitigate there is no CronTabDefinition method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Now let's import the generated code into a Pulumi program that provisions the CR
 ```typescript
 import * as crontabs from "./crontabs"
 import * as pulumi from "@pulumi/pulumi"
+import * as k8s from "@pulumi/kubernetes";
 
 // Register the CronTab CRD.
-const cronTabDefinition = new crontabs.stable.CronTabDefinition("my-crontab-definition")
+const cronTabDefinition = new k8s.yaml.ConfigFile("my-crontab-definition", { file: "resourcedefinition.yaml" });
 
 // Instantiate a CronTab resource.
 const myCronTab = new crontabs.stable.v1.CronTab("my-new-cron-object",


### PR DESCRIPTION
Hi

Started using crd2pulumi recently, and I ran into the same issue as described here https://github.com/pulumi/crd2pulumi/issues/23. I see it might mainly be just the example that threw me off a bit, as the "CronTabDefinition" isn't created as expected according to the example. 

After reading through the issue and the related duplicate issue https://github.com/pulumi/crd2pulumi/issues/36 I get the impression this feature might be difficult or time consuming to implement, and we should maybe look at other ways of getting the CRDs deployed. 

I noticed that the other languages uses a pulumi yaml file deployment in some variant, 

I.e. python
> crontab_definition = k8s.yaml.ConfigFile("my-crontab-definition", **file="resourcedefinition.yaml"**)

I would like to suggest updating the example for TypeScript to reflect the same way of deploying, using the "ConfigFile" endpoint [1].

This way, the example would work "out of the box" and hopefully not cause questions or confusions. I've tested this on my setup and it seems to work as expected.

[1] https://www.pulumi.com/registry/packages/kubernetes/api-docs/yaml/configfile/

