### PR TITLE
Pin the k8s version in the generated resources for node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Pin the Kubernetes version for generated nodejs resources(<https://github.com/pulumi/crd2pulumi/pull/121>)
+
 ## 1.3.0 (2023-12-12)
 
 - Fix: excluding files from unneededGoFiles was not working (<https://github.com/pulumi/crd2pulumi/pull/120>)

--- a/tests/crds/k8sversion/mock_crd.yaml
+++ b/tests/crds/k8sversion/mock_crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  group: k8sversion.pulumi.com
+  names:
+    plural: testresources
+    singular: testresource
+    kind: TestResource
+  scope: Namespaced
+  versions:
+    - test:
+      name: test
+      schema:
+        openAPIV3Schema:
+          properties:
+            testProperty:
+              type: string`

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -124,8 +125,8 @@ func TestKubernetesVersionNodeJs(t *testing.T) {
 		// enter and build the generated package
 		withDir(t, path, func() {
 
-			require.NoError(t, exec.Command("npm", "i").Run())
-			require.NoError(t, exec.Command("npm", "run", "build").Run())
+			runRequireNoError(t, exec.Command("npm", "install"))
+			runRequireNoError(t, exec.Command("npm", "run", "build"))
 
 			// extract the version returned by a resource
 			appendFile(t, "bin/index.js", "\nconsole.log((new k8sversion.test.TestResource('test')).__version)")
@@ -156,4 +157,15 @@ func appendFile(t *testing.T, filename, content string) {
 	defer f.Close()
 
 	_, err = f.WriteString(content)
+}
+
+func runRequireNoError(t *testing.T, cmd *exec.Cmd) {
+	buf := new(bytes.Buffer)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	err := cmd.Run()
+	if err != nil {
+		t.Log(buf)
+	}
+	require.NoError(t, err)
 }

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var languages = []string{"dotnet", "go", "nodejs", "python"}
@@ -116,4 +117,43 @@ func TestCRDsWithUnderscore(t *testing.T) {
 	}
 
 	execCrd2Pulumi(t, "python", "crds/underscored-types/networkpolicy.yaml", validateUnderscore)
+}
+
+func TestKubernetesVersionNodeJs(t *testing.T) {
+	validateVersion := func(t *testing.T, path string) {
+		// enter and build the generated package
+		withDir(t, path, func() {
+
+			require.NoError(t, exec.Command("npm", "i").Run())
+			require.NoError(t, exec.Command("npm", "run", "build").Run())
+
+			// extract the version returned by a resource
+			appendFile(t, "bin/index.js", "\nconsole.log((new k8sversion.test.TestResource('test')).__version)")
+
+			version, err := exec.Command("node", "bin/index.js").Output()
+			require.NoError(t, err)
+			assert.Equal(t, "4.5.5\n", string(version))
+		})
+	}
+
+	execCrd2Pulumi(t, "nodejs", "crds/k8sversion/mock_crd.yaml", validateVersion)
+}
+
+func withDir(t *testing.T, dir string, f func()) {
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(pwd)
+
+	require.NoError(t, os.Chdir(dir))
+
+	f()
+}
+
+func appendFile(t *testing.T, filename, content string) {
+	// extract the version returned by a resource
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	defer f.Close()
+
+	_, err = f.WriteString(content)
 }

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -15,7 +15,6 @@
 package tests
 
 import (
-	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -160,12 +159,9 @@ func appendFile(t *testing.T, filename, content string) {
 }
 
 func runRequireNoError(t *testing.T, cmd *exec.Cmd) {
-	buf := new(bytes.Buffer)
-	cmd.Stdout = buf
-	cmd.Stderr = buf
-	err := cmd.Run()
+	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Log(buf)
+		t.Log(bytes)
 	}
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #28 

crd2pulumi uses codegen in  a kind of funny way to generate resources that act as resources of the kubernetes resource plugin. This means the resource version needs to match a kubernetes plugin version. Generated resources however, default to the version from the package.json, so if the user attempts to give the generated package a version, the engine starts complaining that it can't find a kubernetes plugin with that version.

This change overrides the generated `getVersion()` helper to point to a recent kubernetes release so that the engine can find the plugin even if the user adds a version to the package.json