### PR TITLE
Fix goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Goreleaser publishing dry run
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: latest
-          args: release --rm-dist --skip-publish
+          version: v2.2.0
+          args: release --clean --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Goreleaser publishing dry run
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: v2.2.0
-          args: release --clean --skip-publish
+          version: v1.26.2
+          args: release --rm-dist --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
   push:
     tags:
       - v*.*.*
-      - '!v*.*.*-**'
+      - "!v*.*.*-**"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,8 +28,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: v2.2.0
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Chocolatey Package Deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: v2.2.0
-          args: release --clean
+          version: v1.26.2
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Chocolatey Package Deployment


### PR DESCRIPTION
Goreleaser v2 was released on June 4. We haven't landed any PRs since then so we didn't notice it broke things.

The pins us to version v1.26.2 which was the last working version.