### PR TITLE
Prepare for v1.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.5.2 (2024-09-16)
+
+- Set the pulumi-kubernetes dependency for Python packages to v4.18.0. [#148](https://github.com/pulumi/crd2pulumi/issues/148)
+- Fixed generating Go types for StringMapArrayMap types. [#147](https://github.com/pulumi/crd2pulumi/issues/147)
+
 ## 1.5.1 (2024-09-13)
 
 - Fixed Patch varaints not generated for types that end in List. [#146](https://github.com/pulumi/crd2pulumi/pull/146)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pulumi/pulumi-java/pkg v0.14.0
-	github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240913215025-7155e2ed5604
+	github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240916231657-74673fdf488b
 	github.com/pulumi/pulumi/pkg/v3 v3.130.0
 	github.com/pulumi/pulumi/sdk/v3 v3.130.0
 	github.com/spf13/cobra v1.8.1
@@ -260,5 +260,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/pulumi/pulumi-kubernetes/provider/v4 => github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240914001316-08cb0541a657

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.14.0 h1:CKL7lLF81Fq6VRhA5TNFsSMnHraTNCUzIhqCzYX8Wzk=
 github.com/pulumi/pulumi-java/pkg v0.14.0/go.mod h1:VybuJMWJtJc9ZNbt1kcYH4TbpocMx9mEi7YWL2Co99c=
-github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240914001316-08cb0541a657 h1:HrSLsABbaFT0TQsAzh2thOri4xGmj+X+P8waXzH4RzE=
-github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240914001316-08cb0541a657/go.mod h1:glS84cIQOYkQBbAtHQjlNnx28XAZrPMwlPah4+Izj2U=
+github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240916231657-74673fdf488b h1:Eb5/zL+RY2TnHn0zciQ+3lylAuvsWoi8XvLKRpc9xGE=
+github.com/pulumi/pulumi-kubernetes/provider/v4 v4.0.0-20240916231657-74673fdf488b/go.mod h1:glS84cIQOYkQBbAtHQjlNnx28XAZrPMwlPah4+Izj2U=
 github.com/pulumi/pulumi/pkg/v3 v3.130.0 h1:lS51XeCnhg72LXkMiw2FP1cGP+Y85wYD3quWhCPD5+M=
 github.com/pulumi/pulumi/pkg/v3 v3.130.0/go.mod h1:jhZ1Ug5Rl1qivexgEWvmwSWYIT/jRnKSFhLwwv6PrZ0=
 github.com/pulumi/pulumi/sdk/v3 v3.130.0 h1:gGJNd+akPqhZ+vrsZmAjSNJn6kGJkitjjkwrmIQMmn8=

--- a/pkg/codegen/nodejs.go
+++ b/pkg/codegen/nodejs.go
@@ -49,10 +49,9 @@ func GenerateNodeJS(pg *PackageGenerator, name string) (map[string]*bytes.Buffer
 	}
 	files["utilities.ts"] = bytes.ReplaceAll(utilities,
 		[]byte("export function getVersion(): string {"),
-		[]byte(`export const getVersion: () => string = () => "4.18.0"
+		[]byte(fmt.Sprintf(`export const getVersion: () => string = () => "%s"
 
-function unusedGetVersion(): string {`),
-	)
+function unusedGetVersion(): string {`, KubernetesProviderVersion)))
 
 	// Create a helper `meta/v1.ts` script that exports the ObjectMeta class from the SDK. If there happens to already
 	// be a `meta/v1.ts` file, then just append the script.

--- a/pkg/codegen/packagegenerator.go
+++ b/pkg/codegen/packagegenerator.go
@@ -24,6 +24,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
+const (
+	KubernetesProviderVersion string = "4.18.0"
+)
+
 // PackageGenerator generates code for multiple CustomResources
 type PackageGenerator struct {
 	// CustomResourceGenerators contains a slice of all CustomResourceGenerators

--- a/pkg/codegen/python.go
+++ b/pkg/codegen/python.go
@@ -62,6 +62,9 @@ func GeneratePython(pg *PackageGenerator, name string) (map[string]*bytes.Buffer
 
 	buffers := map[string]*bytes.Buffer{}
 	for name, code := range files {
+		if name == "pyproject.toml" {
+			code = bytes.ReplaceAll(code, []byte(`0.0.0+dev`), []byte(KubernetesProviderVersion))
+		}
 		buffers[name] = bytes.NewBuffer(code)
 	}
 	return buffers, nil

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -130,7 +130,7 @@ func genPackage(version string, crgenerators []CustomResourceGenerator, includeO
 	// This will only currently work for Go and Python as they have the correct annotations to serialize/deserialize
 	// the hyphenated fields to their non-hyphenated equivalents.
 	// See: https://github.com/pulumi/crd2pulumi/issues/43
-	pkgSpec := gen.PulumiSchema(unstructuredOpenAPISchema, gen.WithAllowHyphens(true), gen.WithAddPulumiKubernetesDependency("4.18.0"))
+	pkgSpec := gen.PulumiSchema(unstructuredOpenAPISchema, gen.WithAllowHyphens(true), gen.WithPulumiKubernetesDependency("4.18.0"))
 
 	// Populate the package spec with information used in previous versions of crd2pulumi to maintain consistency
 	// with older versions.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -130,7 +130,7 @@ func genPackage(version string, crgenerators []CustomResourceGenerator, includeO
 	// This will only currently work for Go and Python as they have the correct annotations to serialize/deserialize
 	// the hyphenated fields to their non-hyphenated equivalents.
 	// See: https://github.com/pulumi/crd2pulumi/issues/43
-	pkgSpec := gen.PulumiSchema(unstructuredOpenAPISchema, gen.WithAllowHyphens(true), gen.WithPulumiKubernetesDependency("4.18.0"))
+	pkgSpec := gen.PulumiSchema(unstructuredOpenAPISchema, gen.WithAllowHyphens(true), gen.WithPulumiKubernetesDependency(KubernetesProviderVersion))
 
 	// Populate the package spec with information used in previous versions of crd2pulumi to maintain consistency
 	// with older versions.

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/crd2pulumi/cmd"
+	"github.com/pulumi/crd2pulumi/pkg/codegen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -243,7 +244,7 @@ func TestKubernetesVersionNodeJs(t *testing.T) {
 
 			version, err := exec.Command("node", "bin/index.js").Output()
 			require.NoError(t, err)
-			assert.Equal(t, "4.18.0\n", string(version))
+			assert.Equal(t, codegen.KubernetesProviderVersion+"\n", string(version))
 		})
 	}
 

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -177,6 +177,11 @@ func TestCRDsFromUrl(t *testing.T) {
 			name: "Argo Application Set",
 			url:  "https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/crds/applicationset-crd.yaml",
 		},
+		{
+			// https://github.com/pulumi/crd2pulumi/issues/147
+			name: "Prometheus Operator",
+			url:  "https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.76.2/bundle.yaml",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR contains 3 changes/commits and is intended to be rebased and merged to maintain commit history.

### Changes made:

1. Removed go mod replacements with upstream changes now merged to `master`.
2. Fixed generating Golang types for StringMapArrayMap properties. We now correctly type this nested field. An additional CRD is now installed and compiled in our integration test suite.
4. Fixed setting v4.18.0 as the p-k dependency for generated Python packages.

### Related Issues:
Resolves: #147, resolves #148