### PR TITLE
Fix type for generated resource metadata fields in NodeJS.

### DIFF
--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -259,6 +259,29 @@ func TestKubernetesVersionNodeJs(t *testing.T) {
 	execCrd2Pulumi(t, "nodejs", "crds/k8sversion/mock_crd.yaml", validateVersion)
 }
 
+func TestNodeJsObjectMeta(t *testing.T) {
+	validateVersion := func(t *testing.T, path string) {
+		// enter and build the generated package
+		withDir(t, path, func() {
+			runRequireNoError(t, exec.Command("npm", "install"))
+			runRequireNoError(t, exec.Command("npm", "run", "build"))
+
+			filename := filepath.Join(path, "k8sversion", "test", "testResource.ts")
+			t.Logf("validating objectmeta type in %s", filename)
+
+			testResource, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatalf("expected to read generated NodeJS code: %s", err)
+			}
+
+			assert.Contains(t, string(testResource), "public readonly metadata!: pulumi.Output<ObjectMetaOutput>;", "expected metadata output type")
+			assert.Contains(t, string(testResource), "metadata?: pulumi.Input<ObjectMeta>;", "expected metadata input type")
+		})
+	}
+
+	execCrd2Pulumi(t, "nodejs", "crds/k8sversion/mock_crd.yaml", validateVersion)
+}
+
 func withDir(t *testing.T, dir string, f func()) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err)


### PR DESCRIPTION
This corrects the type used for the metadata field in generated custom resources to use the output variant of ObjectMeta, allowing for simpler plumbing of metadata outputs, such as the resource name, into inputs of other resources.