### PR TITLE
Fix NodeJS metadata type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- NodeJS no longer uses a custom object metadata type for inputs and outputs. (https://github.com/pulumi/crd2pulumi/issues/158)
+
 ## 1.5.3 (2024-09-30)
 
 - Fix crd2pulumi not generating all CRD versions. [#152](https://github.com/pulumi/crd2pulumi/issues/152)

--- a/pkg/codegen/nodejs.go
+++ b/pkg/codegen/nodejs.go
@@ -30,7 +30,7 @@ export type ObjectMetaPatch = k8s.types.input.meta.v1.ObjectMetaPatch;
 `
 
 func GenerateNodeJS(pg *PackageGenerator, name string) (map[string]*bytes.Buffer, error) {
-	pkg := pg.SchemaPackage()
+	pkg := pg.SchemaPackageWithObjectMetaType()
 	oldName := pkg.Name
 	pkg.Name = name
 


### PR DESCRIPTION
All of our languages except NodeJS use `SchemaPackageWithObjectMetaType`. As a result, Node exposes only input types for object metadata which makes it awkward to consume downstream.

I'm assuming https://github.com/pulumi/crd2pulumi/pull/143 didn't change this for backwards-compatibility reasons, or maybe it was overlooked. I _think_ it is safe to continue generating the `ObjectMeta` type alias (in case users are importing it) but use the native k8s input/output type on resources.

Fixes https://github.com/pulumi/crd2pulumi/issues/158