### PR TITLE
Prepare v1.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 1.6.2 (2026-05-06)
+
+### Changed
+- Switched .NET code generation to use `pulumi-dotnet`'s codegen package. [#266](https://github.com/pulumi/crd2pulumi/pull/266)
+- Bumped `pulumi/pulumi` to v3.231.0 and refreshed first-party Pulumi dependencies.
+- Bumped `pulumi-kubernetes` provider digest.
+- Bumped `pulumi-dotnet` language host to v3.103.0.
+
+### Security
+- Bumped `github.com/go-git/go-git/v5` to v5.18.0.
+- Bumped `go.opentelemetry.io/otel/sdk` to v1.43.0.
+- Bumped `github.com/cloudflare/circl` to v1.6.3.
+
 ## 1.6.0 (2025-10-17)
 
 - Configurable package namespaces/prefixes. (https://github.com/pulumi/crd2pulumi/pull/247)


### PR DESCRIPTION
## Summary
- Adds the v1.6.2 changelog entry covering everything since v1.6.1 — primarily dependency bumps plus the .NET codegen library swap (#266).
- Recommending **patch** (not minor): no user-facing API changes; consistent with the v1.6.0 → v1.6.1 precedent (also dep-only).

Fixes https://github.com/pulumi/crd2pulumi/issues/327.

## Test plan
- [ ] Merge this PR.
- [ ] Tag `v1.6.2` on master and push to trigger the `release` workflow (goreleaser + chocolatey).
- [ ] Verify the GitHub release, Homebrew tap, and Chocolatey package publish cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)