### PR TITLE
Wrap property names with `.` or `-` symbols in quotes for Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.3 (2026-05-28)
+
+- NodeJS code generation now wraps generated property names with `-` or `.` in them in quotes to prevent syntax errors [#339](https://github.com/pulumi/crd2pulumi/issues/339)
+
 ## 1.6.2 (2026-05-06)
 
 ### Changed

--- a/pkg/codegen/nodejs.go
+++ b/pkg/codegen/nodejs.go
@@ -17,6 +17,10 @@ package codegen
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 )
@@ -28,6 +32,8 @@ const nodejsMetaFile = `import * as k8s from "@pulumi/kubernetes";
 export type ObjectMeta = k8s.types.input.meta.v1.ObjectMeta;
 export type ObjectMetaPatch = k8s.types.input.meta.v1.ObjectMetaPatch;
 `
+
+var nodeJSQuotedPropertyDeclaration = regexp.MustCompile(`(?m)^(\s*(?:(?:declare\s+)?public\s+readonly\s+)?)([A-Za-z_$][A-Za-z0-9_$]*(?:[.-][A-Za-z0-9_$]+)+)(\??:\s)`)
 
 func GenerateNodeJS(pg *PackageGenerator, cs *CodegenSettings) (map[string]*bytes.Buffer, error) {
 	pkg := pg.SchemaPackageWithObjectMetaType()
@@ -54,6 +60,8 @@ func GenerateNodeJS(pg *PackageGenerator, cs *CodegenSettings) (map[string]*byte
 
 function unusedGetVersion(): string {`, KubernetesProviderVersion)))
 
+	quoteInvalidNodeJSPropertyNames(files)
+
 	// Create a helper `meta/v1.ts` script that exports the ObjectMeta class from the SDK. If there happens to already
 	// be a `meta/v1.ts` file, then just append the script.
 	if code, ok := files[nodejsMetaPath]; !ok {
@@ -68,4 +76,53 @@ function unusedGetVersion(): string {`, KubernetesProviderVersion)))
 	}
 
 	return buffers, nil
+}
+
+func quoteInvalidNodeJSPropertyNames(files map[string][]byte) {
+	invalidProperties := map[string]struct{}{}
+
+	for path, code := range files {
+		if !strings.HasSuffix(path, ".ts") {
+			continue
+		}
+
+		for _, match := range nodeJSQuotedPropertyDeclaration.FindAllSubmatch(code, -1) {
+			invalidProperties[string(match[2])] = struct{}{}
+		}
+
+		files[path] = nodeJSQuotedPropertyDeclaration.ReplaceAll(code, []byte(`${1}"${2}"${3}`))
+	}
+
+	if len(invalidProperties) == 0 {
+		return
+	}
+
+	propertyNames := make([]string, 0, len(invalidProperties))
+	for propertyName := range invalidProperties {
+		propertyNames = append(propertyNames, propertyName)
+	}
+	sort.Slice(propertyNames, func(i, j int) bool {
+		return len(propertyNames[i]) > len(propertyNames[j])
+	})
+
+	for path, code := range files {
+		if !strings.HasSuffix(path, ".ts") {
+			continue
+		}
+
+		for _, propertyName := range propertyNames {
+			quotedPropertyName := strconv.Quote(propertyName)
+			code = bytes.ReplaceAll(code,
+				[]byte("args?."+propertyName),
+				[]byte("args?.["+quotedPropertyName+"]"))
+			code = bytes.ReplaceAll(code,
+				[]byte("args."+propertyName),
+				[]byte("args["+quotedPropertyName+"]"))
+			code = bytes.ReplaceAll(code,
+				[]byte("this."+propertyName),
+				[]byte("this["+quotedPropertyName+"]"))
+		}
+
+		files[path] = code
+	}
 }

--- a/tests/crds/regression/dotted-symbols/README.md
+++ b/tests/crds/regression/dotted-symbols/README.md
@@ -1,0 +1,1 @@
+Regression test to verify the fix for https://github.com/pulumi/crd2pulumi/issues/339

--- a/tests/crds/regression/dotted-symbols/dot-test.yml
+++ b/tests/crds/regression/dotted-symbols/dot-test.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  group: dottest.pulumi.com
+  names:
+    kind: DotTest
+    listKind: DotTestList
+    plural: DotTests
+    singular: Dottest
+  scope: Namespaced
+  versions:
+    - name: DotTest
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                has.a.dot:
+                  type: string


### PR DESCRIPTION
Fixes: #339 

**This change is fully vide-coded**

I just compiled the binary for windows and tested it with the crds from the issue above to ensure, that the issue is resolved by the ai changes.

Edit:

## What has changed

This PR uses a new regex to wrap invalid Node.js property names, like property names that include a dot or a dash, in quotes so that they don't cause syntactic errors. This change only affects the Node.js package generation. 