### PR TITLE
Fix Python Kubernetes provider version generation

### DIFF
--- a/pkg/codegen/python.go
+++ b/pkg/codegen/python.go
@@ -65,6 +65,18 @@ func GeneratePython(pg *PackageGenerator, cs *CodegenSettings) (map[string]*byte
 		files[metaPath] = append(code, []byte(pythonMetaFile)...)
 	}
 
+	// Pin the kubernetes provider version used
+	utilitiesPath := filepath.Join(pythonPackageDir, "_utilities.py")
+	utilities, ok := files[utilitiesPath]
+	if !ok {
+		return nil, fmt.Errorf("cannot find generated _utilities.py")
+	}
+	files[utilitiesPath] = bytes.ReplaceAll(
+		utilities,
+		[]byte("def get_version():\n     return _version_str"),
+		[]byte(fmt.Sprintf("def get_version():\n     return \"%s\"", KubernetesProviderVersion)),
+	)
+
 	buffers := map[string]*bytes.Buffer{}
 	for name, code := range files {
 		if name == "pyproject.toml" {

--- a/tests/crds_test.go
+++ b/tests/crds_test.go
@@ -261,6 +261,23 @@ func TestKubernetesVersionNodeJs(t *testing.T) {
 	execCrd2Pulumi(t, "nodejs", "crds/k8sversion/mock_crd.yaml", validateVersion)
 }
 
+func TestKubernetesVersionPython(t *testing.T) {
+	validateVersion := func(t *testing.T, path string) {
+		filename := filepath.Join(path, "pulumi_crds", "_utilities.py")
+		t.Logf("validating kubernetes provider version in %s", filename)
+
+		utilities, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("expected to read generated Python utilities: %s", err)
+		}
+
+		assert.Contains(t, string(utilities), fmt.Sprintf("return \"%s\"", codegen.KubernetesProviderVersion))
+		assert.NotContains(t, string(utilities), "return _version_str")
+	}
+
+	execCrd2Pulumi(t, "python", "crds/k8sversion/mock_crd.yaml", validateVersion)
+}
+
 func TestNodeJsObjectMeta(t *testing.T) {
 	validateVersion := func(t *testing.T, path string) {
 		// enter and build the generated package


### PR DESCRIPTION
NodeJS generation already rewrites `getVersion()` to return `KubernetesProviderVersion`. Python generation only updates `pyproject.toml`, but leaves `_utilities.get_version()` returning the generated CRD package version. Since `crd2pulumi` packages use the kubernetes provider token, Pulumi then attempts to download a kubernetes provider plugin matching the CRD package version.

This change mirrors the NodeJS behavior for Python.